### PR TITLE
fix: modular workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
     uses: ./.github/workflows/publish/version-tag.yml
 
   dokka:
-    uses: ./github/workflows/publish/dokka.yml
+    uses: ./.github/workflows/publish/dokka.yml
     needs: [version-tag]
 
   dependency-submission:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   auto-assign-author:
-    uses: ./.github/workflows/pull-request/auto-assign-author.yml
+    uses: ./.github/workflows/auto-assign-author.yml
 
   build:
     uses: ./.github/workflows/pull-request/build.yml

--- a/.github/workflows/pull-request/automerge-dependabot.yml
+++ b/.github/workflows/pull-request/automerge-dependabot.yml
@@ -9,11 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
     steps:
-      - name: Install GitHub CLI
-        run: |
-          sudo apt-get update
-          sudo apt-get install gh
-
       - name: Approve Dependabot PR
         run: gh pr review ${{ github.event.pull_request.number }} --approve
         env:


### PR DESCRIPTION
This pull request includes updates to GitHub Actions workflows to fix file path references and remove unnecessary steps. The most important changes involve correcting relative paths in workflow files and simplifying the `automerge-dependabot.yml` job by removing redundant steps.

### Workflow file path corrections:

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L14-R14): Fixed the relative path for the `dokka` job to ensure it correctly references `.github/workflows/publish/dokka.yml` instead of `github/workflows/publish/dokka.yml`.
* [`.github/workflows/pull-request.yml`](diffhunk://#diff-b71166ed0f585913318ed46933ff9b12901e211de3ac88c40de03f0a944c0ae0L16-R16): Updated the `auto-assign-author` job to reference the correct relative path `.github/workflows/auto-assign-author.yml`.

### Workflow simplifications:

* [`.github/workflows/pull-request/automerge-dependabot.yml`](diffhunk://#diff-8963efae4d93c5eaea335e6c85331bdf443ad6c21677c4afcf30abb1c8e9e75dL12-L16): Removed the step to install the GitHub CLI (`gh`) since it is not required for the `Approve Dependabot PR` step.