### PR TITLE
fix: PR lacks write perm for issues, so remove

### DIFF
--- a/.github/workflows/assign-author.yml
+++ b/.github/workflows/assign-author.yml
@@ -1,4 +1,4 @@
-name: Auto Assign Author
+name: Assign Author
 
 on:
   workflow_call: # Allows this workflow to be called from other workflows.

--- a/.github/workflows/auto-assign-author.yml
+++ b/.github/workflows/auto-assign-author.yml
@@ -2,11 +2,8 @@ name: Auto Assign Author
 
 on:
   workflow_call: # Allows this workflow to be called from other workflows.
-  issues:
-    types: [ opened, reopened ]
 
 permissions:
-  issues: write
   pull-requests: write
 
 jobs:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,8 +12,8 @@ permissions:
   pull-requests: write
 
 jobs:
-  auto-assign-author:
-    uses: ./.github/workflows/auto-assign-author.yml
+  assign-author:
+    uses: ./.github/workflows/assign-author.yml
 
   build:
     uses: ./.github/workflows/build.yml

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -14,6 +14,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.head_ref }}
 
       - name: Ensure PR targets main branch
         if: ${{ github.event.pull_request.base.ref != 'main' }}
@@ -113,4 +114,4 @@ jobs:
           git config --global user.email "github-actions@github.com"
           git add gradle/libs.versions.toml
           git diff --cached --exit-code && echo "No changes to commit." || git commit -m "Bump version to $new_version"
-          git push
+          git push origin ${{ github.head_ref }}

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -7,7 +7,7 @@ on:
   workflow_call: # Allows this workflow to be called from other workflows.
 
 jobs:
-  versioning:
+  version-bump:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -28,6 +28,7 @@ jobs:
             echo "author_type=bot" >> $GITHUB_ENV
           else
             echo "author_type=human" >> $GITHUB_ENV
+          fi
 
       - name: Get current version
         id: get_version

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -113,5 +113,9 @@ jobs:
           git config --global user.name "github-actions"
           git config --global user.email "github-actions@github.com"
           git add gradle/libs.versions.toml
-          git diff --cached --exit-code && echo "No changes to commit." || git commit -m "Bump version to $new_version"
+          if git diff --cached --exit-code; then
+            echo "No changes to commit. Skipping push."
+            exit 0
+          fi
+          git commit -m "Bump version to $new_version"
           git push origin ${{ github.head_ref }}


### PR DESCRIPTION
This pull request includes updates to GitHub Actions workflows to improve naming consistency and fix a missing conditional block. The most important changes involve renaming workflows and jobs to align with their functionality and adding a missing `fi` statement in a conditional block.

### Workflow renaming and consistency improvements:
* `.github/workflows/auto-assign-author.yml` was renamed to `.github/workflows/assign-author.yml`, and the workflow name was updated from "Auto Assign Author" to "Assign Author." Additionally, the `permissions` section was adjusted to remove `issues: write` since it is no longer needed.
* Updated `jobs` in `.github/workflows/pull-request.yml` to reference the renamed `assign-author.yml` workflow instead of the old `auto-assign-author.yml` workflow.
* Renamed the `versioning` job to `version-bump` in `.github/workflows/version-bump.yml` for better alignment with the workflow's purpose.

### Bug fix:
* Added a missing `fi` statement to close a conditional block in the `version-bump` job within `.github/workflows/version-bump.yml`. This resolves a syntax issue.